### PR TITLE
Fix variable export in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,15 +4,15 @@ VERSION ?= $(shell git describe --tags --always --dirty --match=v* 2> /dev/null 
             echo v0)
 
 build:
-	export GOFLAGS=-mod=vendor
-	go generate ./...
+	export GOFLAGS=-mod=vendor ; \
+	go generate ./...; \
 	CGO_ENABLED=0 gox -osarch="linux/amd64" -mod vendor -ldflags '-extldflags "-static" -X "main.version=${VERSION}"' github.com/xsteadfastx/jitsiexporter/cmd/jitsiexporter
 
 clean:
 	rm -f jitsiexporter
 
 test:
-	export GOFLAGS=-mod=vendor
+	export GOFLAGS=-mod=vendor ; \
 	go test ./...
 
 lint:


### PR DESCRIPTION
Makefile runs each line of a target in a separate shell, so things like
`export` and `source` do not propagate to the next lines, you must run
the commands in a single shell, which is what I've done in this commit.

With out this change, `make build` fails on my debian linux box.